### PR TITLE
Implement wasm build scripts with small scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# WASM builds
+/dist/bin/

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8"/>
+    <title>Untitled Jam Game - Game Off 2022 by GitHub</title>
+
+    <style>
+        html, body {
+            margin: 0;
+            height: 100%;
+            overflow: hidden;
+        }
+    </style>
+</head>
+
+<script type="module">
+    import init from './bin/game-off-2022.js';
+    init();
+</script>
+
+</html>

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 default:
-  @just --list
+    @just --list
 
 run-dev:
-  cargo run
+    cargo run
+
+build:
+    cargo build --release --target wasm32-unknown-unknown
+    wasm-bindgen --out-dir dist/bin --target web target/wasm32-unknown-unknown/release/game-off-2022.wasm

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,54 @@
+use bevy::prelude::*;
+
 fn main() {
-    println!("Hello, world!");
+    let fullscreen_window = WindowDescriptor {
+        fit_canvas_to_parent: true,
+        ..default()
+    };
+
+    App::new()
+        // TODO Replace with new approach in bevy 0.9 https://discord.com/channels/691052431525675048/750833140746158140/1040301656824348723
+        .insert_resource(fullscreen_window)
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup)
+        .run();
+}
+
+// See https://bevyengine.org/examples/3d/3d-scene/
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // plane
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..default()
+    });
+
+    // cube
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+
+    // light
+    commands.spawn_bundle(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+
+    // camera
+    commands.spawn_bundle(Camera3dBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
 }


### PR DESCRIPTION
The setup function is copy paste from the 3d example scene and will be replaced with the actual game obviously.

Use `just build` to build the project, then open `dist/index.html` to view the game in browser. You may require a small web server, I used IntelliJs built-in web server.