### PR TITLE
Deploy to GitHub pages

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,0 +1,51 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Setup Just
+        uses: extractions/setup-just@v1
+      - name: Setup Rust WebAssembly bindings generator
+        uses: jetli/wasm-bindgen-action@v0.1.0 # Much faster than `$ cargo install wasm-bindgen-cli`
+      - name: Build Rust to WebAssembly target
+        run: just build-web
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The game is based on the cliché: [_“Get lost”_](https://github.com/leereill
 
 - [Rust](https://www.rust-lang.org/tools/install)
 - [`just`](https://github.com/casey/just#packages)
+- [`wasm-bindgen`](https://rustwasm.github.io/wasm-bindgen/reference/cli.html)
 
 ### Running
 

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ _default:
 run-dev:
     cargo run
 
-build:
+build-web:
     cargo build --release --target wasm32-unknown-unknown
     wasm-bindgen --out-dir dist/bin --target web target/wasm32-unknown-unknown/release/game-off-2022.wasm
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-default:
+_default:
     @just --list
 
 run-dev:

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ run-dev:
     cargo run
 
 build-web:
+    rustup target add wasm32-unknown-unknown
     cargo build --release --target wasm32-unknown-unknown
     wasm-bindgen --out-dir dist/bin --target web target/wasm32-unknown-unknown/release/game-off-2022.wasm
 

--- a/justfile
+++ b/justfile
@@ -2,9 +2,14 @@ _default:
     @just --list
 
 run-dev:
+    @just _assert-is-installed cargo
     cargo run
 
 build-web:
+    @just _assert-is-installed rustup
+    @just _assert-is-installed cargo
+    @just _assert-is-installed wasm-bindgen
+
     rustup target add wasm32-unknown-unknown
     cargo build --release --target wasm32-unknown-unknown
     wasm-bindgen --out-dir dist/bin --target web target/wasm32-unknown-unknown/release/game-off-2022.wasm

--- a/justfile
+++ b/justfile
@@ -7,3 +7,12 @@ run-dev:
 build:
     cargo build --release --target wasm32-unknown-unknown
     wasm-bindgen --out-dir dist/bin --target web target/wasm32-unknown-unknown/release/game-off-2022.wasm
+
+_assert-is-installed tool:
+    #!/usr/bin/env bash
+    set -euxo pipefail # https://github.com/casey/just#safer-bash-shebang-recipes
+
+    if ! {{tool}} --version &> /dev/null; then
+        echo "{{tool}} is not installed!";
+        exit 1;
+    fi


### PR DESCRIPTION
Closes #5.

## Why

Since you already facilitated building for the web in #1, it would be criminal not to have some CD on GitHub Pages 😉 

## Notes

- Ought to be merged after #3
- You have to enable Pages in the repository settings:
  - Settings -> Pages -> Build and deployment -> GitHub Actions (Beta)
- After this PR is merged, the workflow will run for the first time on `main`, and then the game will be available _(after around 7 minutes)_ [here](https://salzian.github.io/game-off-2022/) 😄 